### PR TITLE
Add RabbitMQ channel option customization and tests

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
@@ -1,0 +1,96 @@
+using System.Reflection;
+using NSubstitute;
+using RabbitMQ.Client;
+using Shouldly;
+using Wolverine.RabbitMQ.Internal;
+using Xunit;
+
+namespace Wolverine.RabbitMQ.Tests.Internals;
+
+public class ConnectionMonitorTests
+{
+    [Fact]
+    public async Task default_channel_options_do_not_enable_publisher_confirmations()
+    {
+        var transport = new RabbitMqTransport();
+        var monitor = new ConnectionMonitor(transport, ConnectionRole.Sending);
+
+        var connection = Substitute.For<IConnection>();
+        var channel = Substitute.For<IChannel>();
+        CreateChannelOptions? capturedOptions = null;
+
+        connection.CreateChannelAsync(Arg.Do<CreateChannelOptions>(o => capturedOptions = o))
+            .Returns(Task.FromResult(channel));
+
+        SetConnection(monitor, connection);
+
+        await monitor.CreateChannelAsync();
+
+        capturedOptions.ShouldNotBeNull();
+        capturedOptions!.PublisherConfirmationsEnabled.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task configured_channel_options_enable_publisher_confirmations()
+    {
+        var transport = new RabbitMqTransport();
+        transport.ConfigureChannelOptions(options => new CreateChannelOptions(
+            true,
+            options.PublisherConfirmationTrackingEnabled,
+            options.OutstandingPublisherConfirmationsRateLimiter,
+            options.ConsumerDispatchConcurrency));
+
+        var monitor = new ConnectionMonitor(transport, ConnectionRole.Sending);
+
+        var connection = Substitute.For<IConnection>();
+        var channel = Substitute.For<IChannel>();
+        CreateChannelOptions? capturedOptions = null;
+
+        connection.CreateChannelAsync(Arg.Do<CreateChannelOptions>(o => capturedOptions = o))
+            .Returns(Task.FromResult(channel));
+
+        SetConnection(monitor, connection);
+
+        await monitor.CreateChannelAsync();
+
+        capturedOptions.ShouldNotBeNull();
+        capturedOptions!.PublisherConfirmationsEnabled.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task tenant_transport_inherits_channel_options()
+    {
+        var parent = new RabbitMqTransport();
+        parent.ConfigureFactory(f => f.HostName = "localhost");
+        parent.ConfigureChannelOptions(options => new CreateChannelOptions(
+            true,
+            options.PublisherConfirmationTrackingEnabled,
+            options.OutstandingPublisherConfirmationsRateLimiter,
+            options.ConsumerDispatchConcurrency));
+
+        var tenant = new RabbitMqTenant("tenant", "virtual");
+        tenant.Compile(parent);
+
+        var monitor = new ConnectionMonitor(tenant.Transport, ConnectionRole.Sending);
+
+        var connection = Substitute.For<IConnection>();
+        var channel = Substitute.For<IChannel>();
+        CreateChannelOptions? capturedOptions = null;
+
+        connection.CreateChannelAsync(Arg.Do<CreateChannelOptions>(o => capturedOptions = o))
+            .Returns(Task.FromResult(channel));
+
+        SetConnection(monitor, connection);
+
+        await monitor.CreateChannelAsync();
+
+        capturedOptions.ShouldNotBeNull();
+        capturedOptions!.PublisherConfirmationsEnabled.ShouldBeTrue();
+    }
+
+    private static void SetConnection(ConnectionMonitor monitor, IConnection connection)
+    {
+        var field = typeof(ConnectionMonitor).GetField("_connection", BindingFlags.Instance | BindingFlags.NonPublic);
+        field!.SetValue(monitor, connection);
+    }
+}

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
@@ -34,11 +34,10 @@ public class ConnectionMonitorTests
     public async Task configured_channel_options_enable_publisher_confirmations()
     {
         var transport = new RabbitMqTransport();
-        transport.ConfigureChannelOptions(options => new CreateChannelOptions(
-            true,
-            options.PublisherConfirmationTrackingEnabled,
-            options.OutstandingPublisherConfirmationsRateLimiter,
-            options.ConsumerDispatchConcurrency));
+        transport.ConfigureChannelOptions(options => options with
+        {
+            PublisherConfirmationsEnabled = true
+        });
 
         var monitor = new ConnectionMonitor(transport, ConnectionRole.Sending);
 
@@ -62,11 +61,10 @@ public class ConnectionMonitorTests
     {
         var parent = new RabbitMqTransport();
         parent.ConfigureFactory(f => f.HostName = "localhost");
-        parent.ConfigureChannelOptions(options => new CreateChannelOptions(
-            true,
-            options.PublisherConfirmationTrackingEnabled,
-            options.OutstandingPublisherConfirmationsRateLimiter,
-            options.ConsumerDispatchConcurrency));
+        parent.ConfigureChannelOptions(options => options with
+        {
+            PublisherConfirmationsEnabled = true
+        });
 
         var tenant = new RabbitMqTenant("tenant", "virtual");
         tenant.Compile(parent);

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/ConnectionMonitor.cs
@@ -47,7 +47,10 @@ internal class ConnectionMonitor : IAsyncDisposable, IConnectionMonitor
     {
         if (_connection == null) throw new InvalidOperationException("The connection is not initialized");
 
-        return _connection!.CreateChannelAsync();
+        var options = new CreateChannelOptions(false, false, null, null);
+        options = _transport.ApplyChannelOptions(options);
+
+        return _connection.CreateChannelAsync(options);
     }
 
     public ConnectionRole Role { get; }

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTenant.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTenant.cs
@@ -43,6 +43,7 @@ internal class RabbitMqTenant
         }
 
         CloneDeadLetterQueue(parent);
+        CloneChannelOptions(parent);
 
         return Transport!;
     }
@@ -56,6 +57,14 @@ internal class RabbitMqTenant
         Transport.DeadLetterQueue.BindingName = parent.DeadLetterQueue.BindingName;
         Transport.DeadLetterQueue.ConfigureQueue = parent.DeadLetterQueue.ConfigureQueue;
         Transport.DeadLetterQueue.ConfigureExchange = parent.DeadLetterQueue.ConfigureExchange;
+    }
+
+    private void CloneChannelOptions(RabbitMqTransport parent)
+    {
+        if (parent.ChannelOptionsCustomization != null)
+        {
+            Transport.CopyChannelOptionsFrom(parent);
+        }
     }
 
     public Task ConnectAsync(RabbitMqTransport parent, IWolverineRuntime runtime)

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
@@ -64,6 +64,12 @@ public class RabbitMqTransportExpression : BrokerExpression<RabbitMqTransport, R
         return this;
     }
 
+    public RabbitMqTransportExpression ConfigureChannelOptions(Func<CreateChannelOptions, CreateChannelOptions> configure)
+    {
+        Transport.ConfigureChannelOptions(configure);
+        return this;
+    }
+
     /// <summary>
     /// Make any necessary customizations to the Rabbit MQ client's ConnectionFactory
     /// </summary>

--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ/Internal/RabbitMqTransportExpression.cs
@@ -64,6 +64,13 @@ public class RabbitMqTransportExpression : BrokerExpression<RabbitMqTransport, R
         return this;
     }
 
+    /// <summary>
+    /// Customize the <see cref="CreateChannelOptions"/> used when Wolverine opens Rabbit MQ channels.
+    /// Use this to enable publisher confirmations or adjust other channel behaviors.
+    /// </summary>
+    /// <param name="configure">Callback that receives the current options and returns the desired configuration.</param>
+    /// <returns>The original <see cref="RabbitMqTransportExpression"/> for fluent configuration.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="configure"/> is <c>null</c>.</exception>
     public RabbitMqTransportExpression ConfigureChannelOptions(Func<CreateChannelOptions, CreateChannelOptions> configure)
     {
         Transport.ConfigureChannelOptions(configure);


### PR DESCRIPTION
## Summary
- allow RabbitMQ transport to configure channel creation options and propagate the setting to tenants
- ensure ConnectionMonitor builds channels with the configured options
- add tests covering default and customized channel option flows

## Testing
- `~/.dotnet/dotnet test src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj --filter ConnectionMonitorTests`


------
https://chatgpt.com/codex/tasks/task_b_68efaaf1a30c832a86eeace7073de66b