### PR TITLE
Fix ConnectionMonitor channel options without record with

### DIFF
--- a/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
+++ b/src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Internals/ConnectionMonitorTests.cs
@@ -34,10 +34,11 @@ public class ConnectionMonitorTests
     public async Task configured_channel_options_enable_publisher_confirmations()
     {
         var transport = new RabbitMqTransport();
-        transport.ConfigureChannelOptions(options => options with
-        {
-            PublisherConfirmationsEnabled = true
-        });
+        transport.ConfigureChannelOptions(options => new CreateChannelOptions(
+            publisherConfirmationsEnabled: true,
+            publisherConfirmationTrackingEnabled: options.PublisherConfirmationTrackingEnabled,
+            outstandingPublisherConfirmationsRateLimiter: options.OutstandingPublisherConfirmationsRateLimiter,
+            consumerDispatchConcurrency: options.ConsumerDispatchConcurrency));
 
         var monitor = new ConnectionMonitor(transport, ConnectionRole.Sending);
 
@@ -61,10 +62,11 @@ public class ConnectionMonitorTests
     {
         var parent = new RabbitMqTransport();
         parent.ConfigureFactory(f => f.HostName = "localhost");
-        parent.ConfigureChannelOptions(options => options with
-        {
-            PublisherConfirmationsEnabled = true
-        });
+        parent.ConfigureChannelOptions(options => new CreateChannelOptions(
+            publisherConfirmationsEnabled: true,
+            publisherConfirmationTrackingEnabled: options.PublisherConfirmationTrackingEnabled,
+            outstandingPublisherConfirmationsRateLimiter: options.OutstandingPublisherConfirmationsRateLimiter,
+            consumerDispatchConcurrency: options.ConsumerDispatchConcurrency));
 
         var tenant = new RabbitMqTenant("tenant", "virtual");
         tenant.Compile(parent);


### PR DESCRIPTION
## Summary
- update RabbitMQ ConnectionMonitor tests to configure CreateChannelOptions without using record `with`
- ensure publisher confirmation settings are preserved while copying other option values

## Testing
- `dotnet test src/Transports/RabbitMQ/Wolverine.RabbitMQ.Tests/Wolverine.RabbitMQ.Tests.csproj --filter ConnectionMonitorTests`


------
https://chatgpt.com/codex/tasks/task_b_68f0bab8d844832a86decd8aff26551c